### PR TITLE
adding windows support?

### DIFF
--- a/install.js
+++ b/install.js
@@ -26,6 +26,16 @@ function filename() {
     }
   }
 }
+function executableFilename() {
+  switch (process.platform) {
+    case "win32": {
+      return "deno.exe";
+    }
+    default: {
+      return "deno";
+    }
+  }
+}
 
 function main() {
   const dlUrl =
@@ -41,7 +51,7 @@ function main() {
     // 2. Saves it in temp dir
     res.pipe(fs.createWriteStream(zipPath)).on("close", () => {
       // 3. Extracts `deno` entry to bin path.
-      new AdmZip(zipPath).extractEntryTo("deno", binPath, true, true);
+      new AdmZip(zipPath).extractEntryTo(executableFilename(), binPath, true, true);
       fs.unlinkSync(zipPath);
     });
   });


### PR DESCRIPTION
I get an error during installation on windows.
```
C:\Users\...\test_project\node_modules\adm-zip\adm-zip.js:512
                                throw new Error(Utils.Errors.NO_ENTRY);
                                ^

Error: Entry doesn't exist
    at Object.extractEntryTo (C:\Users\...\test_project\node_modules\adm-zip\adm-zip.js:512:11)
    at WriteStream.<anonymous> (C:\Users\...\test_project\node_modules\deno-bin\install.js:44:27)
    at WriteStream.emit (events.js:315:20)
    at emitCloseNT (internal/streams/destroy.js:87:10)
    at processTicksAndRejections (internal/process/task_queues.js:79:21)
npm WARN enoent ENOENT: no such file or directory, open 'C:\Users\...\test_project\package.json'
npm WARN test_project No description
npm WARN test_project No repository field.
npm WARN test_project No README data
npm WARN test_project No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! deno-bin@1.9.2 install: `node install.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the deno-bin@1.9.2 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\azusa\AppData\Roaming\npm-cache\_logs\2021-04-25T14_57_54_542Z-debug.log
```
I forked and fixed it for my own use, but what about merging this? (If you are not accepting pull requests,  please feel free to close this.)