### PR TITLE
Download Deno on first use

### DIFF
--- a/bin/deno
+++ b/bin/deno
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+{
+  node "$(dirname "$0")/../install.js"
+  exec "$0" "$@"
+}


### PR DESCRIPTION
Makes the package work with `npm ci --ignore-scripts`. Works on Linux, not tested on Windows.