### PR TITLE
Pin adm-zip to 0.5.10 (#26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   },
   "homepage": "https://github.com/kt3k/deno-bin#readme",
   "dependencies": {
-    "adm-zip": "^0.5.4"
+    "adm-zip": "0.5.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,7 @@
 # yarn lockfile v1
 
 
-adm-zip@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.4.tgz#af1f08c92cf9aa21b525231bce340fbdc39bd265"
-  integrity sha512-GMQg1a1cAegh+/EgWbz+XHZrwB467iB/IgtToldvxs7Xa5Br8mPmvCeRfY/Un2fLzrlIPt6Yu7Cej+8Ut9TGPg==
-
-follow-redirects@^1.10.0:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+adm-zip@0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.10.tgz#4a51d5ab544b1f5ce51e1b9043139b639afff45b"
+  integrity sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==


### PR DESCRIPTION
The issue is that this might not solve all the existing versions of deno-bin that have already been released because the package.json in those releases are tied to ^0.5.4 which will cause them to install the latest version of adm-zip, which has issues.

The best solution is for adm-zip to fix https://github.com/cthackers/adm-zip/issues/473.

Resolves #26 
